### PR TITLE
Feature/production data commitment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",
@@ -53,6 +53,7 @@
         "nodemon": "^3.0.2",
         "pino-colada": "^2.2.2",
         "prettier": "^3.1.0",
+        "reflect-metadata": "^0.1.13",
         "sinon": "^17.0.1",
         "supertest": "^6.3.3",
         "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {
@@ -57,6 +57,7 @@
     "nodemon": "^3.0.2",
     "pino-colada": "^2.2.2",
     "prettier": "^3.1.0",
+    "reflect-metadata": "^0.1.13",
     "sinon": "^17.0.1",
     "supertest": "^6.3.3",
     "ts-node": "^10.9.1",

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -1,8 +1,10 @@
 import { IocContainer } from '@tsoa/runtime'
 import { container } from 'tsyringe'
 
+import Commitment from './lib/services/commitment'
 import Database from './lib/db'
 
+container.register(Commitment, { useValue: new Commitment('shake128') })
 container.register(Database, { useValue: new Database() })
 
 export const iocContainer: IocContainer = {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -64,6 +64,11 @@ const insertCertificateRowZ = z.object({
   hydrogen_quantity_mwh: z.number(),
   original_token_id: z.union([z.number(), z.null()]),
   latest_token_id: z.union([z.number(), z.null()]),
+  commitment: z.string(),
+  commitment_salt: z.union([z.string(), z.null()]),
+  production_start_time: z.union([z.date(), z.null()]),
+  production_end_time: z.union([z.date(), z.null()]),
+  energy_consumed_mwh: z.union([z.number(), z.null()]),
 })
 
 const certificateRowZ = insertCertificateRowZ.extend({

--- a/src/lib/db/migrations/20230310111029_initial.ts
+++ b/src/lib/db/migrations/20230310111029_initial.ts
@@ -24,6 +24,11 @@ export async function up(knex: Knex): Promise<void> {
     def.integer('embodied_co2').nullable().index('embodied_co2_index').defaultTo(null)
     def.string('energy_owner', 48).notNullable()
     def.string('hydrogen_owner', 48).notNullable()
+    def.dateTime('production_start_time').nullable().defaultTo(null)
+    def.dateTime('production_end_time').nullable().defaultTo(null)
+    def.integer('energy_consumed_mwh').nullable().defaultTo(null)
+    def.string('commitment_salt', 32).nullable().defaultTo(null)
+    def.string('commitment', 32).notNullable()
     def
       .enum('state', ['pending', 'initiated', 'issued', 'revoked', 'cancelled'], {
         useNative: true,

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -44,7 +44,10 @@ describe('eventProcessor', function () {
               ['hydrogen_owner', 'heidi-hydrogen-producer'],
               ['energy_owner', 'emma-energy-producer'],
             ]),
-            metadata: new Map([['hydrogen_quantity_mwh', '42']]),
+            metadata: new Map([
+              ['hydrogen_quantity_mwh', '42'],
+              ['commitment', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+            ]),
           },
         ],
       })
@@ -58,6 +61,7 @@ describe('eventProcessor', function () {
         hydrogen_quantity_mwh: 42,
         latest_token_id: 1,
         original_token_id: 1,
+        commitment: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       })
     })
 

--- a/src/lib/indexer/changeSet.ts
+++ b/src/lib/indexer/changeSet.ts
@@ -16,6 +16,11 @@ export type CertificateRecord =
       state: 'pending' | 'initiated' | 'issued' | 'revoked'
       latest_token_id: number
       original_token_id: number
+      commitment: string
+      commitment_salt: null
+      production_start_time: null
+      production_end_time: null
+      energy_consumed_mwh: null
     }
   | {
       type: 'update'

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -78,6 +78,11 @@ const DefaultEventProcessors: EventProcessors = {
       hydrogen_quantity_mwh: parseIntegerOrThrow(getOrError(cert.metadata, 'hydrogen_quantity_mwh')),
       latest_token_id,
       original_token_id: latest_token_id,
+      commitment: getOrError(cert.metadata, 'commitment'),
+      commitment_salt: null,
+      energy_consumed_mwh: null,
+      production_end_time: null,
+      production_start_time: null,
     }
 
     return {

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -29,7 +29,7 @@ export const processInitiateCert = (certificate: CertificateRow): Payload => ({
         '@version': { type: 'LITERAL', value: '1' },
         '@type': { type: 'LITERAL', value: 'InitiatedCert' },
         hydrogen_quantity_mwh: { type: 'LITERAL', value: certificate.hydrogen_quantity_mwh.toString() },
-        commitment: { type: 'LITERAL', value: "Paulius's have been commited" },
+        commitment: { type: 'LITERAL', value: certificate.commitment },
       },
     },
   ],

--- a/src/lib/services/__tests__/commitment.test.ts
+++ b/src/lib/services/__tests__/commitment.test.ts
@@ -1,0 +1,166 @@
+import 'reflect-metadata'
+
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+import Commitment from '../commitment'
+
+import type { ALGOS } from '../commitment'
+
+describe('Commitment', function () {
+  describe('ctor', function () {
+    it('should validate and store block size for valid algorithm', function () {
+      const commitment = new Commitment('shake128')
+      expect(commitment.algo).to.equal('shake128')
+      expect(commitment.blockSize).to.equal(128)
+    })
+
+    it('should error if hash algorithm is unsupported by system', function () {
+      let error: Error | null = null
+      try {
+        new Commitment('unsupported' as ALGOS)
+      } catch (err) {
+        if (err instanceof Error) {
+          error = err
+        }
+      }
+      expect(error).instanceOf(Error)
+    })
+  })
+
+  describe('build', function () {
+    it('should build a salt and digest for a string record', async function () {
+      const commitment = new Commitment('sha256')
+      const result = await commitment.build({ foo: 'bar' })
+
+      expect(result.salt).to.match(/^[0-9a-f]{64}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{64}$/)
+    })
+
+    it('should build a salt and digest with shake128', async function () {
+      const commitment = new Commitment('shake128')
+      const result = await commitment.build({ foo: 'bar' })
+
+      expect(result.salt).to.match(/^[0-9a-f]{32}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{32}$/)
+    })
+
+    it('should build a salt and digest with shake256', async function () {
+      const commitment = new Commitment('shake256')
+      const result = await commitment.build({ foo: 'bar' })
+
+      expect(result.salt).to.match(/^[0-9a-f]{64}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{64}$/)
+    })
+
+    it('should build a salt and digest for a number record', async function () {
+      const commitment = new Commitment('sha256')
+      const result = await commitment.build({ foo: 42 })
+
+      expect(result.salt).to.match(/^[0-9a-f]{64}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{64}$/)
+    })
+
+    it('should build a salt and digest for a Date record', async function () {
+      const commitment = new Commitment('sha256')
+      const result = await commitment.build({ foo: new Date() })
+
+      expect(result.salt).to.match(/^[0-9a-f]{64}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{64}$/)
+    })
+
+    it('should build a salt and digest for multiple records', async function () {
+      const commitment = new Commitment('sha256')
+      const result = await commitment.build({ a: 'foo', b: 42, c: new Date() })
+
+      expect(result.salt).to.match(/^[0-9a-f]{64}$/)
+      expect(result.digest).to.match(/^[0-9a-f]{64}$/)
+    })
+  })
+
+  for (const algo of ['sha256', 'shake128', 'shake256'] as const) {
+    describe(`validate (${algo})`, function () {
+      it('should validate like records', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record, salt, digest)
+        expect(result).to.equal(true)
+      })
+
+      it('should validate like re-ordered records', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { b: 42, c: new Date(), a: 'foo' }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(true)
+      })
+
+      it('should not validate for unlike records (missing prop)', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { a: 'foo', b: 42 }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(false)
+      })
+
+      it('should not validate for unlike records (additional prop)', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { ...record, d: 'bar' }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(false)
+      })
+
+      it('should not validate for unlike records (string prop)', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { ...record, a: 'bar' }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(false)
+      })
+
+      it('should not validate for unlike records (number prop)', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { ...record, b: 1 }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(false)
+      })
+
+      it('should not validate for unlike records (date prop)', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const record2 = { ...record, c: new Date(0) }
+        const commitment = new Commitment(algo)
+
+        const { salt, digest } = await commitment.build(record)
+        const result = commitment.validate(record2, salt, digest)
+        expect(result).to.equal(false)
+      })
+
+      it('should not validate with incorrect salt', async function () {
+        const record = { a: 'foo', b: 42, c: new Date() }
+        const commitment = new Commitment(algo)
+
+        const { digest } = await commitment.build(record)
+        const result = commitment.validate(
+          record,
+          algo === 'shake128' ? 'aaaaaaaaaaaaaaaa' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          digest
+        )
+        expect(result).to.equal(false)
+      })
+    })
+  }
+})

--- a/src/lib/services/commitment.ts
+++ b/src/lib/services/commitment.ts
@@ -1,0 +1,68 @@
+import crypto from 'node:crypto'
+import util from 'node:util'
+import { singleton } from 'tsyringe'
+
+const { getHashes, createHash } = crypto
+const generateKey = util.promisify(crypto.generateKey)
+
+const algos = ['sha256', 'shake128', 'shake256'] as const
+type ALGOS_TUPLE = typeof algos
+export type ALGOS = ALGOS_TUPLE[number]
+const getBlockLength = (algo: ALGOS): number => {
+  switch (algo) {
+    case 'sha256':
+      return 256
+    case 'shake128':
+      return 128
+    case 'shake256':
+      return 256
+  }
+}
+
+@singleton()
+export default class Commitment {
+  blockSize: number
+
+  constructor(public algo: ALGOS) {
+    const hashes = new Set(getHashes())
+    if (!hashes.has(algo)) {
+      throw new Error(`Invalid cypher: ${algo}`)
+    }
+    this.blockSize = getBlockLength(algo)
+  }
+
+  build = async (values: Record<string, string | number | Date>): Promise<{ salt: string; digest: string }> => {
+    const salt = (await generateKey('hmac', { length: this.blockSize })).export()
+    const hasher = createHash(this.algo)
+    hasher.update(salt)
+    const digest = this.buildDigest(hasher, values)
+
+    return {
+      salt: salt.toString('hex'),
+      digest,
+    }
+  }
+
+  validate = (values: Record<string, string | number | Date>, salt: string, digest: string): boolean => {
+    const saltAsBuffer = Buffer.from(salt, 'hex')
+    const hasher = createHash(this.algo)
+    hasher.update(saltAsBuffer)
+    return this.buildDigest(hasher, values) === digest
+  }
+
+  private buildDigest = (hasher: crypto.Hmac, values: Record<string, string | number | Date>): string => {
+    const sortedPairs = Object.entries(values).sort(([a], [b]) => a.localeCompare(b, 'en'))
+    for (const [key, value] of sortedPairs) {
+      let valStr: string | null = null
+      if (typeof value === 'number') {
+        valStr = '' + value
+      } else if (value instanceof Date) {
+        valStr = value.toISOString()
+      } else valStr = value
+
+      hasher.update(key, 'utf8')
+      hasher.update(valStr, 'utf8')
+    }
+    return hasher.digest().toString('hex')
+  }
+}

--- a/src/models/certificate.ts
+++ b/src/models/certificate.ts
@@ -11,6 +11,11 @@ export type GetCertificateResponse = {
   latest_token_id?: number | null
   created_at: Date
   updated_at: Date
+  commitment: string
+  commitment_salt?: string | null
+  production_start_time?: Date | null
+  production_end_time?: Date | null
+  energy_consumed_mwh?: number | null
 }
 export type ListCertificatesResponse = GetCertificateResponse[]
 export type GetTransactionResponse = {
@@ -27,10 +32,23 @@ export type ListTransactionResponse = GetTransactionResponse[]
  * Certificate Request Body example
  * @example {
  *   "hydrogen_quantity_mwh": 1,
- *   "energy_owner": "emma"
+ *   "energy_owner": "emma",
+ *   "production_start_time": "2023-01-01T00:00:00.000Z",
+ *   "production_end_time": "2023-01-01T12:00:00.000Z",
+ *   "energy_consumed_mwh": 1,
  * }
  */
 export type Payload = {
   hydrogen_quantity_mwh: number
   energy_owner: string
+  production_start_time: Date
+  production_end_time: Date
+  energy_consumed_mwh: number
+}
+
+export type UpdatePayload = {
+  production_start_time: Date
+  production_end_time: Date
+  energy_consumed_mwh: number
+  commitment_salt: string
 }

--- a/test/helpers/routeHelper.ts
+++ b/test/helpers/routeHelper.ts
@@ -14,6 +14,15 @@ export const post = async (
   return request(app).post(endpoint).send(body).set(headers)
 }
 
+export const put = async (
+  app: express.Express,
+  endpoint: string,
+  body: object,
+  headers: object = {}
+): Promise<request.Test> => {
+  return request(app).put(endpoint).send(body).set(headers)
+}
+
 export const postFile = async (
   app: express.Express,
   endpoint: string,

--- a/test/integration/offchain/certificate.test.ts
+++ b/test/integration/offchain/certificate.test.ts
@@ -1,0 +1,55 @@
+import { describe, before } from 'mocha'
+import { Express } from 'express'
+import { expect } from 'chai'
+
+import createHttpServer from '../../../src/server'
+import { put } from '../../helpers/routeHelper'
+
+import { cleanup, updateSeed } from '../../seeds/certificate'
+import { CertificateRow } from '../../../src/lib/db'
+
+describe('certificate', () => {
+  let certificate: CertificateRow
+  let app: Express
+
+  before(async () => {
+    app = await createHttpServer()
+  })
+
+  beforeEach(async function () {
+    certificate = await updateSeed()
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should update the certificate if the correct commitment data is provided', async function () {
+    const { status, body } = await put(app, `/v1/certificate/${certificate.id}`, {
+      production_start_time: new Date('2023-12-01T00:00:00.000Z'),
+      production_end_time: new Date('2023-12-02T00:00:00.000Z'),
+      energy_consumed_mwh: 2,
+      commitment_salt: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+
+    expect(status).to.equal(200)
+    expect(body).to.deep.contain({
+      production_start_time: '2023-12-01T00:00:00.000Z',
+      production_end_time: '2023-12-02T00:00:00.000Z',
+      energy_consumed_mwh: 2,
+      commitment_salt: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+  })
+
+  it('should error if the incorrect commitment data is provided', async function () {
+    const { status, body } = await put(app, `/v1/certificate/${certificate.id}`, {
+      production_start_time: new Date('2023-12-01T00:00:00.000Z'),
+      production_end_time: new Date('2023-12-02T00:00:00.000Z'),
+      energy_consumed_mwh: 3,
+      commitment_salt: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+
+    expect(status).to.equal(400)
+    expect(body).to.equal('Commitment did not match update')
+  })
+})

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -37,7 +37,13 @@ describe('on-chain', function () {
       const lastTokenId = await node.getLastTokenId()
       const {
         body: { id: certId },
-      } = await post(context.app, '/v1/certificate', { energy_owner: notSelfAlias, hydrogen_quantity_mwh: 1 })
+      } = await post(context.app, '/v1/certificate', {
+        energy_owner: notSelfAlias,
+        hydrogen_quantity_mwh: 1,
+        production_start_time: new Date('2023-12-01T00:00:00.000Z'),
+        production_end_time: new Date('2023-12-02T00:00:00.000Z'),
+        energy_consumed_mwh: 2,
+      })
 
       // submit to chain
       const response = await post(context.app, `/v1/certificate/${certId}/initiation`, {})
@@ -52,7 +58,7 @@ describe('on-chain', function () {
       await pollTransactionState(db, transactionId, 'finalised')
 
       const [cert] = await db.get('certificate', { id: certId })
-      expect(cert).to.contain({
+      expect(cert).to.deep.contain({
         id: certId,
         energy_owner: notSelfAddress,
         hydrogen_owner: selfAddress,
@@ -61,7 +67,12 @@ describe('on-chain', function () {
         embodied_co2: null,
         latest_token_id: lastTokenId + 1,
         original_token_id: lastTokenId + 1,
+        production_start_time: new Date('2023-12-01T00:00:00.000Z'),
+        production_end_time: new Date('2023-12-02T00:00:00.000Z'),
+        energy_consumed_mwh: 2,
       })
+      expect(cert.commitment).to.match(/^[0-9a-f]{32}$/)
+      expect(cert.commitment_salt).to.match(/^[0-9a-f]{32}$/)
     })
   })
 })

--- a/test/seeds/certificate.ts
+++ b/test/seeds/certificate.ts
@@ -11,3 +11,22 @@ export const cleanup = async () => {
 export const seed = async () => {
   await cleanup()
 }
+
+export const updateSeed = async () => {
+  await cleanup()
+
+  const [cert] = await db.insert('certificate', {
+    hydrogen_owner: 'heidi',
+    energy_owner: 'emma',
+    hydrogen_quantity_mwh: 1,
+    latest_token_id: 1,
+    original_token_id: 1,
+    commitment: 'ffb693f99a5aca369539a90b6978d0eb', // matches { production_start_time: new Date('2023-12-01T00:00:00.000Z'), production_end_time: new Date('2023-12-02T00:00:00.000Z'), energy_consumed_mwh: 2, commitment_salt: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+    commitment_salt: null,
+    energy_consumed_mwh: null,
+    production_end_time: null,
+    production_start_time: null,
+  })
+
+  return cert
+}


### PR DESCRIPTION
Adds a commitment to produciton data to the certificate so the energy_owner can validate a request to add eCO2 data to it. This have resulted in a few components:

- a `Commitment` class that encapsulates the commitment build and validation
- updates the database and `certificate` routes to include production data
- API `PUT /certificate/{id}` which adds commitement data if it is not already present. The is the API used by the energy owner prior to issueing the certificate