### PR TITLE
HYP-47 Change use of port 5001 throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use a `.env` at root of the repository to set values for the environment variabl
 | LOG_LEVEL              |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
 | USER_URI               |    Y     |           -            | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
 | IPFS_HOST              |    Y     |           -            | Hostname of the `IPFS` node to use for metadata storage                                      |
-| IPFS_PORT              |    N     |         `5001`         | Port of the `IPFS` node to use for metadata storage                                          |
+| IPFS_PORT              |    N     |         `5002`         | Port of the `IPFS` node to use for metadata storage                                          |
 | WATCHER_POLL_PERIOD_MS |    N     |        `10000`         | Number of ms between polling of service state                                                |
 | WATCHER_TIMEOUT_MS     |    N     |         `2000`         | Timeout period in ms for service state                                                       |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     ports:
       - 4001:4001
       - 8080:8080
-      - 5001:5001
+      - 5002:5002
 volumes:
   hyproof-api-storage:
   identity-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     ports:
       - 4001:4001
       - 8080:8080
-      - 5002:5002
+      - 5002:5001
 volumes:
   hyproof-api-storage:
   identity-storage:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,7 +22,7 @@ export default envalid.cleanEnv(process.env, {
   ENABLE_INDEXER: envalid.bool({ default: true }),
   USER_URI: envalid.str({ devDefault: '//Alice' }),
   IPFS_HOST: envalid.host({ devDefault: 'localhost' }),
-  IPFS_PORT: envalid.port({ default: 5001 }),
+  IPFS_PORT: envalid.port({ default: 5002 }),
   WATCHER_POLL_PERIOD_MS: envalid.num({ default: 10 * 1000 }),
   WATCHER_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
 })

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,7 +22,7 @@ export default envalid.cleanEnv(process.env, {
   ENABLE_INDEXER: envalid.bool({ default: true }),
   USER_URI: envalid.str({ devDefault: '//Alice' }),
   IPFS_HOST: envalid.host({ devDefault: 'localhost' }),
-  IPFS_PORT: envalid.port({ default: 5002 }),
+  IPFS_PORT: envalid.port({ default: 5001, devDefault: 5002 }),
   WATCHER_POLL_PERIOD_MS: envalid.num({ default: 10 * 1000 }),
   WATCHER_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
 })


### PR DESCRIPTION
---
Bump use of port 5001 by IPFS to port 5002 throughout codebase to avoid conflicts with AirDrop/AirPlay listener in MacOS

<!--

Have you read our Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/dscp-hyproof-api/.github/blob/main/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [X] Put an X between the brackets on this line if you have done all of the following:
  - Checked the FAQs for common solutions: <https://github.com/digicatapult/dscp-hyproof-api/blob/main/CONTRIBUTING.md/#FAQs>
  - Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Adscp-hyproof-api>

### Description

MacOS uses 5001 for AirPort/AirPlay

### Steps to Reproduce

1. Dockerised IPFS misbehaves e.g. doesn't find peers, update
