### PR TITLE
HYP-9: new process flow added.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/processFlows.dscp
+++ b/processFlows.dscp
@@ -50,6 +50,7 @@ pub fn issue_cert |input: InitiatedCert| => |output: IssuedCert| where {
   output == input,
   input.hydrogen_owner == output.hydrogen_owner,
   input.energy_owner == output.energy_owner,
+  input.regulator == output.regulator,
   output.hydrogen_owner != sender,
   output.regulator != sender,
   output.energy_owner == sender,

--- a/processFlows.dscp
+++ b/processFlows.dscp
@@ -27,7 +27,7 @@ token RevokedCert {
   hydrogen_owner: Role,
   energy_owner: Role,
   regulator: Role,
-  reason: Literal,
+  reason: File,
 }
 
 /*
@@ -51,6 +51,7 @@ pub fn issue_cert |input: InitiatedCert| => |output: IssuedCert| where {
   input.hydrogen_owner == output.hydrogen_owner,
   input.energy_owner == output.energy_owner,
   input.regulator == output.regulator,
+  input.energy_owner != output.regulator,
   output.hydrogen_owner != sender,
   output.regulator != sender,
   output.energy_owner == sender,

--- a/processFlows.dscp
+++ b/processFlows.dscp
@@ -11,6 +11,7 @@
 token InitiatedCert {
   hydrogen_owner: Role,
   energy_owner: Role,
+  regulator: Role,
   hydrogen_quantity_mwh: Literal,
   commitment: Literal,
 }
@@ -18,7 +19,15 @@ token InitiatedCert {
 token IssuedCert {
   hydrogen_owner: Role,
   energy_owner: Role,
+  regulator: Role,
   embodied_co2: Literal,
+}
+
+token RevokedCert {
+  hydrogen_owner: Role,
+  energy_owner: Role,
+  regulator: Role,
+  reason: Literal,
 }
 
 /*
@@ -34,6 +43,7 @@ token IssuedCert {
 pub fn initiate_cert || => |output: InitiatedCert| where {
   output.hydrogen_owner == sender,
   output.energy_owner != sender,
+  output.regulator != sender,
 }
 
 pub fn issue_cert |input: InitiatedCert| => |output: IssuedCert| where {
@@ -41,5 +51,16 @@ pub fn issue_cert |input: InitiatedCert| => |output: IssuedCert| where {
   input.hydrogen_owner == output.hydrogen_owner,
   input.energy_owner == output.energy_owner,
   output.hydrogen_owner != sender,
+  output.regulator != sender,
   output.energy_owner == sender,
+}
+
+pub fn revoke_cert |input: IssuedCert| => |output: RevokedCert| where {
+  output == input,
+  input.hydrogen_owner == output.hydrogen_owner,
+  input.energy_owner == output.energy_owner,
+  input.regulator == output.regulator,
+  output.energy_owner != sender,
+  output.hydrogen_owner != sender,
+  output.regulator == sender,
 }

--- a/processFlows.json
+++ b/processFlows.json
@@ -71,6 +71,17 @@
       },
       {
         "Restriction": {
+          "OutputHasRole": {
+            "index": 0,
+            "role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
           "FixedOutputMetadataValueType": {
             "index": 0,
             "metadata_key": "hydrogen_quantity_mwh",
@@ -109,6 +120,23 @@
           "SenderHasOutputRole": {
             "index": 0,
             "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Restriction": "None"
+      },
+      {
+        "Op": "NotL"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "SenderHasOutputRole": {
+            "index": 0,
+            "role_key": "regulator"
           }
         }
       },
@@ -224,6 +252,17 @@
       },
       {
         "Restriction": {
+          "InputHasRole": {
+            "index": 0,
+            "role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
           "FixedInputMetadataValueType": {
             "index": 0,
             "metadata_key": "hydrogen_quantity_mwh",
@@ -262,6 +301,17 @@
           "OutputHasRole": {
             "index": 0,
             "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "OutputHasRole": {
+            "index": 0,
+            "role_key": "regulator"
           }
         }
       },
@@ -363,7 +413,300 @@
         "Restriction": {
           "SenderHasOutputRole": {
             "index": 0,
+            "role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Restriction": "None"
+      },
+      {
+        "Op": "NotL"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "SenderHasOutputRole": {
+            "index": 0,
             "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "name": "revoke_cert",
+    "program": [
+      {
+        "Restriction": {
+          "FixedNumberOfInputs": {
+            "num_inputs": 1
+          }
+        }
+      },
+      {
+        "Restriction": {
+          "FixedNumberOfOutputs": {
+            "num_outputs": 1
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedInputMetadataValue": {
+            "index": 0,
+            "metadata_key": "@type",
+            "metadata_value": {
+              "Literal": "IssuedCert"
+            }
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedInputMetadataValue": {
+            "index": 0,
+            "metadata_key": "@version",
+            "metadata_value": {
+              "Literal": "1"
+            }
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedOutputMetadataValue": {
+            "index": 0,
+            "metadata_key": "@type",
+            "metadata_value": {
+              "Literal": "RevokedCert"
+            }
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedOutputMetadataValue": {
+            "index": 0,
+            "metadata_key": "@version",
+            "metadata_value": {
+              "Literal": "1"
+            }
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "InputHasRole": {
+            "index": 0,
+            "role_key": "hydrogen_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "InputHasRole": {
+            "index": 0,
+            "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "InputHasRole": {
+            "index": 0,
+            "role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedInputMetadataValueType": {
+            "index": 0,
+            "metadata_key": "embodied_co2",
+            "metadata_value_type": "Literal"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "OutputHasRole": {
+            "index": 0,
+            "role_key": "hydrogen_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "OutputHasRole": {
+            "index": 0,
+            "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "OutputHasRole": {
+            "index": 0,
+            "role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "FixedOutputMetadataValueType": {
+            "index": 0,
+            "metadata_key": "reason",
+            "metadata_value_type": "Literal"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "MatchInputOutputMetadataValue": {
+            "input_index": 0,
+            "input_metadata_key": "@original_id",
+            "output_index": 0,
+            "output_metadata_key": "@original_id"
+          }
+        }
+      },
+      {
+        "Restriction": {
+          "InputHasMetadata": {
+            "index": 0,
+            "metadata_key": "@original_id"
+          }
+        }
+      },
+      {
+        "Restriction": {
+          "MatchInputIdOutputMetadataValue": {
+            "input_index": 0,
+            "output_index": 0,
+            "output_metadata_key": "@original_id"
+          }
+        }
+      },
+      {
+        "Op": "InhibitionR"
+      },
+      {
+        "Op": "Xor"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "MatchInputOutputRole": {
+            "input_index": 0,
+            "input_role_key": "hydrogen_owner",
+            "output_index": 0,
+            "output_role_key": "hydrogen_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "MatchInputOutputRole": {
+            "input_index": 0,
+            "input_role_key": "energy_owner",
+            "output_index": 0,
+            "output_role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "SenderHasOutputRole": {
+            "index": 0,
+            "role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Restriction": "None"
+      },
+      {
+        "Op": "NotL"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "SenderHasOutputRole": {
+            "index": 0,
+            "role_key": "hydrogen_owner"
+          }
+        }
+      },
+      {
+        "Restriction": "None"
+      },
+      {
+        "Op": "NotL"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "SenderHasOutputRole": {
+            "index": 0,
+            "role_key": "regulator"
           }
         }
       },

--- a/processFlows.json
+++ b/processFlows.json
@@ -394,6 +394,19 @@
       },
       {
         "Restriction": {
+          "MatchInputOutputRole": {
+            "input_index": 0,
+            "input_role_key": "regulator",
+            "output_index": 0,
+            "output_role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
           "SenderHasOutputRole": {
             "index": 0,
             "role_key": "hydrogen_owner"
@@ -662,6 +675,19 @@
             "input_role_key": "energy_owner",
             "output_index": 0,
             "output_role_key": "energy_owner"
+          }
+        }
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
+          "MatchInputOutputRole": {
+            "input_index": 0,
+            "input_role_key": "regulator",
+            "output_index": 0,
+            "output_role_key": "regulator"
           }
         }
       },

--- a/processFlows.json
+++ b/processFlows.json
@@ -407,6 +407,25 @@
       },
       {
         "Restriction": {
+          "MatchInputOutputRole": {
+            "input_index": 0,
+            "input_role_key": "energy_owner",
+            "output_index": 0,
+            "output_role_key": "regulator"
+          }
+        }
+      },
+      {
+        "Restriction": "None"
+      },
+      {
+        "Op": "NotL"
+      },
+      {
+        "Op": "And"
+      },
+      {
+        "Restriction": {
           "SenderHasOutputRole": {
             "index": 0,
             "role_key": "hydrogen_owner"
@@ -612,7 +631,7 @@
           "FixedOutputMetadataValueType": {
             "index": 0,
             "metadata_key": "reason",
-            "metadata_value_type": "Literal"
+            "metadata_value_type": "File"
           }
         }
       },

--- a/src/controllers/v1/certificate/index.ts
+++ b/src/controllers/v1/certificate/index.ts
@@ -78,16 +78,18 @@ export class CertificateController extends Controller {
     {
       hydrogen_quantity_mwh,
       energy_owner,
+      regulator,
       production_start_time,
       production_end_time,
       energy_consumed_mwh,
     }: Certificate.Payload
   ): Promise<Certificate.GetCertificateResponse> {
-    this.log.trace({ identity: this.identity, energy_owner })
+    this.log.trace({ identity: this.identity, energy_owner, regulator })
 
     const identities = {
       hydrogen_owner: await this.identity.getMemberBySelf(),
       energy_owner: await this.identity.getMemberByAlias(energy_owner),
+      regulator: await this.identity.getMemberByAlias(regulator),
     }
 
     const { salt, digest } = await this.commitment.build({
@@ -101,6 +103,7 @@ export class CertificateController extends Controller {
       hydrogen_quantity_mwh,
       hydrogen_owner: identities.hydrogen_owner.address,
       energy_owner: identities.energy_owner.address,
+      regulator: identities.regulator.address,
       latest_token_id: null,
       original_token_id: null,
       production_start_time,
@@ -115,6 +118,7 @@ export class CertificateController extends Controller {
       ...certificate,
       hydrogen_owner: identities.hydrogen_owner.alias,
       energy_owner: identities.energy_owner.alias,
+      regulator: identities.regulator.alias,
       production_start_time: production_start_time,
       production_end_time: production_end_time,
       energy_consumed_mwh,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -61,6 +61,7 @@ export type TransactionRow = z.infer<typeof transactionRowZ>
 const insertCertificateRowZ = z.object({
   hydrogen_owner: z.string(),
   energy_owner: z.string(),
+  regulator: z.string(),
   hydrogen_quantity_mwh: z.number(),
   original_token_id: z.union([z.number(), z.null()]),
   latest_token_id: z.union([z.number(), z.null()]),

--- a/src/lib/db/migrations/20230310111029_initial.ts
+++ b/src/lib/db/migrations/20230310111029_initial.ts
@@ -24,6 +24,7 @@ export async function up(knex: Knex): Promise<void> {
     def.integer('embodied_co2').nullable().index('embodied_co2_index').defaultTo(null)
     def.string('energy_owner', 48).notNullable()
     def.string('hydrogen_owner', 48).notNullable()
+    def.string('regulator', 48).notNullable()
     def.dateTime('production_start_time').nullable().defaultTo(null)
     def.dateTime('production_end_time').nullable().defaultTo(null)
     def.integer('energy_consumed_mwh').nullable().defaultTo(null)

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -43,6 +43,7 @@ describe('eventProcessor', function () {
             roles: new Map([
               ['hydrogen_owner', 'heidi-hydrogen-producer'],
               ['energy_owner', 'emma-energy-producer'],
+              ['regulator', 'raynold-regulator'],
             ]),
             metadata: new Map([
               ['hydrogen_quantity_mwh', '42'],
@@ -78,6 +79,7 @@ describe('eventProcessor', function () {
               roles: new Map([
                 ['hydrogen_owner', 'heidi-hydrogen-producer'],
                 ['energy_owner', 'emma-emma-producer'],
+                ['regulator', 'raynold-regulator'],
               ]),
               metadata: new Map([['hydrogen_quantity_mwh', 'not a number']]),
             },

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -43,7 +43,7 @@ describe('eventProcessor', function () {
             roles: new Map([
               ['hydrogen_owner', 'heidi-hydrogen-producer'],
               ['energy_owner', 'emma-energy-producer'],
-              ['regulator', 'raynold-regulator'],
+              ['regulator', 'reginald-regulator'],
             ]),
             metadata: new Map([
               ['hydrogen_quantity_mwh', '42'],
@@ -79,7 +79,7 @@ describe('eventProcessor', function () {
               roles: new Map([
                 ['hydrogen_owner', 'heidi-hydrogen-producer'],
                 ['energy_owner', 'emma-emma-producer'],
-                ['regulator', 'raynold-regulator'],
+                ['regulator', 'reginald-regulator'],
               ]),
               metadata: new Map([['hydrogen_quantity_mwh', 'not a number']]),
             },

--- a/src/lib/indexer/changeSet.ts
+++ b/src/lib/indexer/changeSet.ts
@@ -12,6 +12,7 @@ export type CertificateRecord =
       id: UUID
       hydrogen_owner: string
       energy_owner: string
+      regulator: string
       hydrogen_quantity_mwh: number
       state: 'pending' | 'initiated' | 'issued' | 'revoked'
       latest_token_id: number

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -75,6 +75,7 @@ const DefaultEventProcessors: EventProcessors = {
       state: 'initiated',
       hydrogen_owner: getOrError(cert.roles, 'hydrogen_owner'),
       energy_owner: getOrError(cert.roles, 'energy_owner'),
+      regulator: getOrError(cert.roles, 'regulator'),
       hydrogen_quantity_mwh: parseIntegerOrThrow(getOrError(cert.metadata, 'hydrogen_quantity_mwh')),
       latest_token_id,
       original_token_id: latest_token_id,

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -24,7 +24,11 @@ export const processInitiateCert = (certificate: CertificateRow): Payload => ({
   inputs: [],
   outputs: [
     {
-      roles: { hydrogen_owner: certificate.hydrogen_owner, energy_owner: certificate.energy_owner },
+      roles: {
+        regulator: certificate.regulator,
+        hydrogen_owner: certificate.hydrogen_owner,
+        energy_owner: certificate.energy_owner,
+      },
       metadata: {
         '@version': { type: 'LITERAL', value: '1' },
         '@type': { type: 'LITERAL', value: 'InitiatedCert' },

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -43,7 +43,11 @@ export const processIssueCert = (certificate: CertificateRow): Payload => ({
   inputs: [certificate.latest_token_id || Number.NaN],
   outputs: [
     {
-      roles: { hydrogen_owner: certificate.hydrogen_owner, energy_owner: certificate.energy_owner },
+      roles: {
+        regulator: certificate.regulator,
+        hydrogen_owner: certificate.hydrogen_owner,
+        energy_owner: certificate.energy_owner,
+      },
       metadata: {
         '@version': { type: 'LITERAL', value: '1' },
         '@type': { type: 'LITERAL', value: 'IssuedCert' },

--- a/src/models/certificate.ts
+++ b/src/models/certificate.ts
@@ -5,6 +5,7 @@ export type GetCertificateResponse = {
   state: 'pending' | 'initiated' | 'issued' | 'revoked'
   hydrogen_owner: string
   energy_owner: string
+  regulator: string
   hydrogen_quantity_mwh: number
   embodied_co2?: number | null
   original_token_id?: number | null
@@ -41,6 +42,7 @@ export type ListTransactionResponse = GetTransactionResponse[]
 export type Payload = {
   hydrogen_quantity_mwh: number
   energy_owner: string
+  regulator: string
   production_start_time: Date
   production_end_time: Date
   energy_consumed_mwh: number

--- a/test/helpers/chainTest.ts
+++ b/test/helpers/chainTest.ts
@@ -9,7 +9,7 @@ import Database, { CertificateRow } from '../../src/lib/db'
 import ChainNode from '../../src/lib/chainNode'
 import { logger } from '../../src/lib/logger'
 import { put } from './routeHelper'
-import { mockEnv, notSelfAddress, selfAddress } from './mock'
+import { mockEnv, notSelfAddress, regulatorAddress, selfAddress } from './mock'
 import { processInitiateCert } from '../../src/lib/payload'
 
 const db = new Database()
@@ -56,6 +56,7 @@ export const withInitialisedCertFromNotSelf = async (context: { app: Express; ce
     processInitiateCert({
       hydrogen_owner: notSelfAddress,
       energy_owner: selfAddress,
+      regulator: regulatorAddress,
       hydrogen_quantity_mwh: 1,
       commitment: 'ffb693f99a5aca369539a90b6978d0eb',
     } as CertificateRow)

--- a/test/helpers/mock.ts
+++ b/test/helpers/mock.ts
@@ -5,6 +5,8 @@ export const selfAlias = 'test-self'
 export const selfAddress = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 export const notSelfAlias = 'test-not-self'
 export const notSelfAddress = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
+export const regulatorAlias = 'test-regulator'
+export const regulatorAddress = '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y'
 
 export function withIdentitySelfMock() {
   let originalDispatcher: Dispatcher
@@ -55,6 +57,28 @@ export function withIdentitySelfMock() {
       .reply(200, {
         alias: notSelfAlias,
         address: notSelfAddress,
+      })
+      .persist()
+
+    mockIdentity
+      .intercept({
+        path: `/v1/members/${regulatorAddress}`,
+        method: 'GET',
+      })
+      .reply(200, {
+        alias: regulatorAlias,
+        address: regulatorAddress,
+      })
+      .persist()
+
+    mockIdentity
+      .intercept({
+        path: `/v1/members/${regulatorAlias}`,
+        method: 'GET',
+      })
+      .reply(200, {
+        alias: regulatorAlias,
+        address: regulatorAddress,
       })
       .persist()
   })

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -17,7 +17,7 @@ import {
   regulatorAlias,
   regulatorAddress,
 } from '../../helpers/mock'
-import Database from '../../../src/lib/db'
+import Database, { CertificateRow } from '../../../src/lib/db'
 import ChainNode from '../../../src/lib/chainNode'
 import { pollTransactionState } from '../../helpers/poll'
 import { withAppAndIndexer, withInitialisedCertFromNotSelf } from '../../helpers/chainTest'

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -9,7 +9,14 @@ import Indexer from '../../../src/lib/indexer'
 import { post } from '../../helpers/routeHelper'
 import { seed, cleanup } from '../../seeds/certificate'
 
-import { selfAddress, notSelfAddress, notSelfAlias, withIdentitySelfMock, regulatorAlias, regulatorAddress } from '../../helpers/mock'
+import {
+  selfAddress,
+  notSelfAddress,
+  notSelfAlias,
+  withIdentitySelfMock,
+  regulatorAlias,
+  regulatorAddress,
+} from '../../helpers/mock'
 import Database from '../../../src/lib/db'
 import ChainNode from '../../../src/lib/chainNode'
 import { pollTransactionState } from '../../helpers/poll'

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -8,7 +8,7 @@ import Indexer from '../../../src/lib/indexer'
 import { post } from '../../helpers/routeHelper'
 import { seed, cleanup } from '../../seeds/certificate'
 
-import { selfAddress, notSelfAddress, notSelfAlias, withIdentitySelfMock } from '../../helpers/mock'
+import { selfAddress, notSelfAddress, notSelfAlias, withIdentitySelfMock, regulatorAddress } from '../../helpers/mock'
 import Database from '../../../src/lib/db'
 import ChainNode from '../../../src/lib/chainNode'
 import { pollTransactionState } from '../../helpers/poll'
@@ -40,6 +40,7 @@ describe('on-chain', function () {
       } = await post(context.app, '/v1/certificate', {
         energy_owner: notSelfAlias,
         hydrogen_quantity_mwh: 1,
+        regulator: regulatorAddress,
         production_start_time: new Date('2023-12-01T00:00:00.000Z'),
         production_end_time: new Date('2023-12-02T00:00:00.000Z'),
         energy_consumed_mwh: 2,
@@ -62,6 +63,7 @@ describe('on-chain', function () {
         id: certId,
         energy_owner: notSelfAddress,
         hydrogen_owner: selfAddress,
+        regulator: regulatorAddress,
         hydrogen_quantity_mwh: 1,
         state: 'initiated',
         embodied_co2: null,

--- a/test/seeds/certificate.ts
+++ b/test/seeds/certificate.ts
@@ -18,7 +18,7 @@ export const updateSeed = async () => {
   const [cert] = await db.insert('certificate', {
     hydrogen_owner: 'heidi',
     energy_owner: 'emma',
-    regulator: 'raynold',
+    regulator: 'reginald',
     hydrogen_quantity_mwh: 1,
     latest_token_id: 1,
     original_token_id: 1,

--- a/test/seeds/certificate.ts
+++ b/test/seeds/certificate.ts
@@ -18,6 +18,7 @@ export const updateSeed = async () => {
   const [cert] = await db.insert('certificate', {
     hydrogen_owner: 'heidi',
     energy_owner: 'emma',
+    regulator: 'raynold',
     hydrogen_quantity_mwh: 1,
     latest_token_id: 1,
     original_token_id: 1,


### PR DESCRIPTION
# What

A new process flow for reveoking an issued ceritficate.
> DSCP-LANG
```
token RevokedCert {
  hydrogen_owner: Role,
  energy_owner: Role,
  regulator: Role,
  reason: Literal,
}
pub fn revoke_cert |input: IssuedCert| => |output: RevokedCert| where {
  output == input,
  input.hydrogen_owner == output.hydrogen_owner,
  input.energy_owner == output.energy_owner,
  output.energy_owner != sender,
  output.hydrogen_owner != sender,
  output.regulator == sender,
}
```

> On Chain
```
'Successfully loaded 3/3 processes'
{
  initiate_cert: {
    type: 'ok',
    message: 'Skipping: process initiate_cert is already created.',
    result: { name: 'initiate_cert', version: 1, status: 'Enabled' }
  },
  issue_cert: {
    type: 'ok',
    message: 'Skipping: process issue_cert is already created.',
    result: { name: 'issue_cert', version: 1, status: 'Enabled' }
  },
  revoke_cert: {
    type: 'ok',
    message: 'Transaction for new process revoke_cert has been successfully submitted',
    result: { name: 'revoke_cert', version: 1, status: 'Enabled' }
  }
}
```