### PR TITLE
Bug/co2 double

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/v1/certificate/index.ts
+++ b/src/controllers/v1/certificate/index.ts
@@ -63,6 +63,7 @@ export class CertificateController extends Controller {
           ...cert,
           energy_owner: (await getMemberPromise(cert.energy_owner)).alias,
           hydrogen_owner: (await getMemberPromise(cert.hydrogen_owner)).alias,
+          regulator: (await getMemberPromise(cert.regulator)).alias,
         }
       })
     )

--- a/src/lib/db/migrations/20230310111029_initial.ts
+++ b/src/lib/db/migrations/20230310111029_initial.ts
@@ -20,8 +20,8 @@ export async function up(knex: Knex): Promise<void> {
 
   await knex.schema.createTable('certificate', (def) => {
     def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
-    def.integer('hydrogen_quantity_mwh').notNullable().index('hydrogen_quantity_mwh_index')
-    def.integer('embodied_co2').nullable().index('embodied_co2_index').defaultTo(null)
+    def.integer('hydrogen_quantity_mwh').notNullable()
+    def.double('embodied_co2').nullable().defaultTo(null)
     def.string('energy_owner', 48).notNullable()
     def.string('hydrogen_owner', 48).notNullable()
     def.string('regulator', 48).notNullable()

--- a/test/helpers/mock.ts
+++ b/test/helpers/mock.ts
@@ -99,7 +99,7 @@ export function withExternalServicesMock() {
             to: '2023-12-02T00:00:00.000Z',
             intensity: {
               actual: 100,
-              forecast: 100,
+              forecast: 123.456789123,
               index: 'moderate',
             },
           },

--- a/test/helpers/mock.ts
+++ b/test/helpers/mock.ts
@@ -98,8 +98,8 @@ export function withExternalServicesMock() {
             from: '2023-12-01T00:00:00.000Z',
             to: '2023-12-02T00:00:00.000Z',
             intensity: {
-              actual: 100,
-              forecast: 123.456789123,
+              actual: 123.456789123,
+              forecast: 100,
               index: 'moderate',
             },
           },

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -139,7 +139,7 @@ describe('on-chain', function () {
         expect(cert).to.deep.contain({
           id: context.cert.id,
           state: 'issued',
-          embodied_co2: 200000,
+          embodied_co2: 246913.578246,
           latest_token_id: lastTokenId + 1,
         })
       })


### PR DESCRIPTION
Fixes a bug where a none integer embodied_co2 causes an error on database insertion. Also fixes a bug where the regulator persona was not being converted back to an alias on get certfificate APIs