### PR TITLE
Change codeowners to software-engineering team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Github CODEOWNERS file
 
 # Global code-owners for this repository
-* @mattdean-digicatapult @jonmattgray @n3op2
+* @digicatapult/software-engineering

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Updates codeowners to @digicatapult/software-engineering for easier maintenance 
