### PR TITLE
Hyp 65 wrong ports in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use a `.env` at root of the repository to set values for the environment variabl
 | DB_USERNAME            |    Y     |          -          | The database username                                                                        |
 | DB_PASSWORD            |    Y     |          -          | The database password                                                                        |
 | IDENTITY_SERVICE_HOST  |    Y     |          -          | Hostname of the `dscp-identity-service`                                                      |
-| IDENTITY_SERVICE_PORT  |    N     |       `3000`        | Port of the `dscp-identity-service`                                                          |
+| IDENTITY_SERVICE_PORT  |    N     |       `3002`        | Port of the `dscp-identity-service`                                                          |
 | NODE_HOST              |    Y     |          -          | The hostname of the `dscp-node` the API should connect to                                    |
 | NODE_PORT              |    N     |       `9944`        | The port of the `dscp-node` the API should connect to                                        |
 | LOG_LEVEL              |    N     |       `info`        | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
@@ -161,9 +161,9 @@ The 3-party demonstration creates 3 personas with different roles, given below. 
 
 The single-party version only uses:
 
-- [localhost:8000/swagger](http://localhost:8000/swagger/#/)
+- HyProof API: [localhost:3000/swagger](http://localhost:8000/swagger/#/)
 
-- [localhost:9000/v1/swagger](http://localhost:9000/v1/swagger/#/)
+- Identity Service: [localhost:3002/v1/swagger](http://localhost:9000/v1/swagger/#/)
 
 ### Using the HyProof API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
`README.md` has the following conflicting information:
- HyProof API is on port 3000
- Identity Service is on port 3000

Says that starting `docker-compose` puts the identity service on port 8000, and the HyProof API on port 9000

`docker-compose` single party version has the identity service on port 3002

This corrects the readme to align to the `docker-compose`