### PR TITLE
Chore/fix 3 personas swagger json bug fix

### DIFF
--- a/docker-compose-3-persona.yml
+++ b/docker-compose-3-persona.yml
@@ -118,6 +118,7 @@ services:
     command: /bin/sh -c "
       sleep 10 &&
       npx knex migrate:latest --knexfile build/lib/db/knexfile &&
+      sleep 10 &&
       npx @digicatapult/dscp-process-management@latest create -h hydrogen-producer-node -p 9944 -u //Alice -f ./processFlows.json &&
       npm start"
     environment:

--- a/docker-compose-3-persona.yml
+++ b/docker-compose-3-persona.yml
@@ -116,9 +116,8 @@ services:
       context: './'
       dockerfile: 'Dockerfile'
     command: /bin/sh -c "
-      sleep 10 &&
+      sleep 20 &&
       npx knex migrate:latest --knexfile build/lib/db/knexfile &&
-      sleep 10 &&
       npx @digicatapult/dscp-process-management@latest create -h hydrogen-producer-node -p 9944 -u //Alice -f ./processFlows.json &&
       npm start"
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "type": "module",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,6 @@
       "types": ["types"]
     }
   },
-  "exclude": ["**/*.test.ts", "test", "**/__test__"]
+  "include": ["src/**/*.ts", "src/swagger.json"],
+  "exclude": ["**/*.test.ts", "test", "**/__test__", "**/__tests__"]
 }


### PR DESCRIPTION
---
name: Three personas setup bugfix
about: Fixing the 3 personas swagger json bug
---

<!--

Have you read our Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/dscp-hyproof-api/.github/blob/main/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Checked the FAQs for common solutions

- [x] Checked that your issue isn't already filed

### Description

<!-- Description of the issue -->

When trying to run the 3 personas setup with `docker-compose -f docker-compose-3-persona.yml up -d --build`, the following error appears

```
[Error: ENOENT: no such file or directory, open '/dscp-hyproof-api/build/swagger.json']
```

### Steps to Reproduce

1. Delete every docker image related to this project and remove all containers **`docker-compose -f docker-compose-3-persona.yml down -v --remove-orphans`**
2. Re-build **`docker-compose -f docker-compose-3-persona.yml up -d --build`** and run
3. Check the logs **`docker-compose -f docker-compose-3-persona.yml logs`**

**Expected behaviour:**

<!-- What you expect to happen -->

The 3 persona docker setup should work as usual.

**Actual behaviour:**

<!-- What actually happens -->

The swagger GUI for persona 01, 02 and 03 doesn't work.

**Reproduces how often:**

<!-- What percentage of the time does it reproduce? -->

### Versions

<!-- You can get this information from copy and pasting the version on the home page or via package.json. Also, please include the OS and what version of the OS you're running. -->

MacOs

### Additional Information

<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

There seems to be a problem. The swagger API GUI client doesn’t seem to start. This is for Persona 01, 02 and 03, as in **`localhost:8000/swagger`**, **`localhost:8010/swagger`** and **`localhost:8020/swagger`** respectively.

This is due to the fact that during the build process, all the necessary files are being created inserted into the **`./build/`** folder, like the **`index.js`** file but not the **`swagger.json`** file, for some reason. This is due to one of the upgrades that haven been applied recently.

One simple solution seems to be to add **`"include": ["src/**/*.*", "src/swagger.json"],`** into the main **`tsconfig.json`** file.

To make sure the first persona starts, adding a delay between the db migration and the insertion of the flow seems to perform better, as in **`sleep 10 &&`** after **`npx knex migrate:latest --knexfile build/lib/db/knexfile &&`**  in the 3 personas docker file.

---
