### PR TITLE
Fix test contagion in controller unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/v1/attachment/__tests__/index.test.ts
+++ b/src/controllers/v1/attachment/__tests__/index.test.ts
@@ -18,35 +18,38 @@ describe('v1/attachment', () => {
   const database: Database = new Database()
   const ipfs: Ipfs = new Ipfs(new Env())
 
-  const stubs = {
-    getFile: sinon
-      .stub(ipfs, 'getFile' as any)
-      .callsFake(async () => ({ blob: { arrayBuffer: () => '0'.repeat(1024) }, filename: 'a' })),
-    addFile: sinon.stub(ipfs, 'addFile' as any).callsFake(async () => 'QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn'),
-    get: sinon.stub(database, 'get').callsFake(async () => [octetExample]),
-    update: sinon.stub(database, 'update' as any).callsFake(async (_, updates: any) => [
-      {
-        ...octetExample,
-        ...updates,
-      },
-    ]),
-    insert: sinon
-      .stub(database, 'insert' as any)
-      .callsFake((_, data: any) => [
-        { ...data, created_at: new Date('2024-01-09T08:41:16.243Z'), id: 'attachment-insert-test' },
+  const mkStubs = () => {
+    sinon.restore()
+    return {
+      getFile: sinon
+        .stub(ipfs, 'getFile' as any)
+        .callsFake(async () => ({ blob: { arrayBuffer: () => '0'.repeat(1024) }, filename: 'a' })),
+      addFile: sinon
+        .stub(ipfs, 'addFile' as any)
+        .callsFake(async () => 'QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn'),
+      get: sinon.stub(database, 'get').callsFake(async () => [octetExample]),
+      update: sinon.stub(database, 'update' as any).callsFake(async (_, updates: any) => [
+        {
+          ...octetExample,
+          ...updates,
+        },
       ]),
+      insert: sinon
+        .stub(database, 'insert' as any)
+        .callsFake((_, data: any) => [
+          { ...data, created_at: new Date('2024-01-09T08:41:16.243Z'), id: 'attachment-insert-test' },
+        ]),
+    }
   }
+  let stubs: ReturnType<typeof mkStubs>
 
   before(() => {
+    stubs = mkStubs()
     controller = new attachment(database, ipfs)
   })
 
   afterEach(() => {
-    stubs.get.resetHistory()
-    stubs.getFile.resetHistory()
-    stubs.insert.resetHistory()
-    stubs.get.resetHistory()
-    stubs.update.resetHistory()
+    stubs = mkStubs()
   })
 
   describe('create() - POST /', () => {

--- a/src/controllers/v1/transaction/__tests__/index.test.ts
+++ b/src/controllers/v1/transaction/__tests__/index.test.ts
@@ -19,14 +19,21 @@ describe('v1/transaction', () => {
   let controller: TransactionController
 
   const database: Database = new Database()
-  const getStub = sinon.stub(database, 'get' as any).callsFake(() => [{ ...example, id: 'test-1' }, example])
+
+  const mkStub = () => {
+    sinon.restore()
+    return sinon.stub(database, 'get' as any).callsFake(() => [{ ...example, id: 'test-1' }, example])
+  }
+
+  let getStub: ReturnType<typeof mkStub>
 
   before(() => {
+    getStub = mkStub()
     controller = new TransactionController(database)
   })
 
   afterEach(() => {
-    getStub.resetHistory()
+    getStub = mkStub()
   })
 
   describe('get() - GET /', () => {


### PR DESCRIPTION
The unit tests currently are highly coupled to each other because of the polution of the `stubs` object between tests. This causes certain tests to fail when disabling other tests or for tests to fail when run in isolation.

This PR resolves this by ensuring all stubs are reset after each test. It's not a perfect solution and my preference would have been to ensure correct stubbing in a `beforeEach` but the highly nested test suite and extensive usage of nested befores would make a much bigger change. I think this is a step in the right direction and at least means tests can now be run individually.  