### PR TITLE
HYP-131 Bug/invalid db filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-hyproof-api",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-hyproof-api",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "An OpenAPI API service for DSCP",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/v1/attachment/__tests__/index.test.ts
+++ b/src/controllers/v1/attachment/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import Database from '../../../../lib/db/index.js'
 import { octetExample, jsonExample } from './fixtures.js'
 import Ipfs from '../../../../lib/ipfs.js'
 import { BadRequest, InternalServerError, NotFound } from '../../../../lib/error-handler/index.js'
-import { AttachmentRow } from '../../../../lib/db/types.js'
+import { AttachmentRow, Where } from '../../../../lib/db/types.js'
 
 describe('v1/attachment', () => {
   let response: any
@@ -171,7 +171,8 @@ describe('v1/attachment', () => {
 
   describe('getAll() - GET /', () => {
     beforeEach(async () => {
-      stubs.get.callsFake(async () => [octetExample, jsonExample]), (response = await controller.getAll())
+      stubs.get.callsFake(async () => [octetExample, jsonExample])
+      response = await controller.getAll()
     })
 
     describe('if none found it', () => {
@@ -203,6 +204,19 @@ describe('v1/attachment', () => {
           size: 26,
         },
       ])
+    })
+
+    describe('passes created_after condition', () => {
+      beforeEach(async () => {
+        response = await controller.getAll('2024-01-01')
+      })
+
+      it('should fetch from db with conditions', () => {
+        const expectedCondition = [['created_at', '>=', new Date('2024-01-01')]] as Where<'attachment'>
+
+        expect(stubs.get.lastCall.args[0]).to.equal('attachment')
+        expect(stubs.get.lastCall.args[1]).to.deep.equal(expectedCondition)
+      })
     })
   })
 

--- a/src/controllers/v1/attachment/index.ts
+++ b/src/controllers/v1/attachment/index.ts
@@ -55,10 +55,10 @@ export class attachment extends Controller {
 
   @Get('/')
   @SuccessResponse(200, 'returns all attachment')
-  public async getAll(@Query() createdAt?: DATE): Promise<ListAttachmentsResponse> {
+  public async getAll(@Query() created_after?: DATE): Promise<ListAttachmentsResponse> {
     this.log.debug('retrieving all attachments')
 
-    return await this.db.get('attachment', createdAt ? [['created_at', '>=', new Date(createdAt)]] : undefined)
+    return await this.db.get('attachment', created_after ? [['created_at', '>=', new Date(created_after)]] : undefined)
   }
 
   @Post('/')

--- a/src/controllers/v1/certificate/__tests__/index.test.ts
+++ b/src/controllers/v1/certificate/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import ChainNode from '../../../../lib/chainNode.js'
 import Commitment from '../../../../lib/services/commitment.js'
 import EmissionsCalculator from '../../../../lib/services/emissionsCalculator.js'
 import { BadRequest, InternalServerError, NotFound } from '../../../../lib/error-handler/index.js'
-import { CertificateRow, TransactionRow } from '../../../../lib/db/types.js'
+import { CertificateRow, TransactionRow, Where } from '../../../../lib/db/types.js'
 import { certExamples, attachmentExample, transactionExample } from './fixtures.js'
 
 describe('v1/certificate', () => {
@@ -168,6 +168,22 @@ describe('v1/certificate', () => {
         energy_owner: 'emma2-test',
         regulator: 'ray-test',
         hydrogen_owner: 'heidi',
+      })
+    })
+
+    describe('with params', () => {
+      beforeEach(async () => {
+        response = await controller.getAll('2024-01-01', '2024-01-02')
+      })
+
+      it('should fetch from db with conditions', () => {
+        const expectedCondition = [
+          ['created_at', '>=', new Date('2024-01-01')],
+          ['updated_at', '>=', new Date('2024-01-02')],
+        ] as Where<'certificate'>
+
+        expect(stubs.get.lastCall.args[0]).to.equal('certificate')
+        expect(stubs.get.lastCall.args[1]).to.deep.equal(expectedCondition)
       })
     })
   })

--- a/src/controllers/v1/certificate/index.ts
+++ b/src/controllers/v1/certificate/index.ts
@@ -168,9 +168,10 @@ export class CertificateController extends Controller {
    */
   @Get('/')
   @Response<NotFound>(404, '<item> not found')
-  public async getAll(@Query() createdAt?: DATE): Promise<ListCertificatesResponse> {
-    const where: Where<'certificate'> = {}
-    if (createdAt) where.created_at = new Date(createdAt)
+  public async getAll(@Query() created_after?: DATE, @Query() updated_after?: DATE): Promise<ListCertificatesResponse> {
+    const where: Where<'certificate'> = []
+    if (created_after) where.push(['created_at', '>=', new Date(created_after)])
+    if (updated_after) where.push(['updated_at', '>=', new Date(updated_after)])
 
     const found = await this.db.get('certificate', where)
     const certificates = await this.mapIdentities(found)

--- a/src/controllers/v1/transaction/__tests__/index.test.ts
+++ b/src/controllers/v1/transaction/__tests__/index.test.ts
@@ -43,7 +43,19 @@ describe('v1/transaction', () => {
           response = await controller.get(api_type)
 
           expect(getStub.lastCall.args[0]).to.equal('transaction')
-          expect(getStub.lastCall.args[1]).to.to.deep.contain({ api_type })
+          expect(getStub.lastCall.args[1].length).to.equal(1)
+          expect(getStub.lastCall.args[1][0]).to.deep.contain({ api_type })
+          expect(response[1]).to.deep.contain(example)
+        })
+
+        it(` - [${api_type}] with args`, async () => {
+          response = await controller.get(api_type, 'finalised', '2024-01-01', '2024-01-02')
+
+          expect(getStub.lastCall.args[0]).to.equal('transaction')
+          expect(getStub.lastCall.args[1].length).to.equal(3)
+          expect(getStub.lastCall.args[1][0]).to.deep.equal({ api_type, state: 'finalised' })
+          expect(getStub.lastCall.args[1][1]).to.deep.equal(['created_at', '>=', new Date('2024-01-01')])
+          expect(getStub.lastCall.args[1][2]).to.deep.equal(['updated_at', '>=', new Date('2024-01-02')])
           expect(response[1]).to.deep.contain(example)
         })
       })
@@ -60,7 +72,7 @@ describe('v1/transaction', () => {
       })
     })
 
-    it('returns transactions by updated_since query param', async () => {
+    it('returns transactions by updated_after query param', async () => {
       response = await controller.get(undefined, undefined, '2024-01-10')
 
       expect(getStub.lastCall.args[0]).to.equal('transaction')

--- a/src/controllers/v1/transaction/index.ts
+++ b/src/controllers/v1/transaction/index.ts
@@ -12,6 +12,7 @@ import type {
   ListTransactionResponse,
   TransactionState,
 } from '../../../models/transaction.js'
+import { Where } from '../../../lib/db/types.js'
 
 @injectable()
 @Route('v1/transaction')
@@ -36,13 +37,17 @@ export class TransactionController extends Controller {
   public async get(
     @Query() api_type?: TransactionApiType,
     @Query() state?: TransactionState,
-    @Query() updated_since?: DATE
+    @Query() created_after?: DATE,
+    @Query() updated_after?: DATE
   ): Promise<ListTransactionResponse> {
-    const where: { state?: TransactionState; api_type?: TransactionApiType; updated_since?: DATE } = {
-      state,
-      api_type,
-      updated_since,
-    }
+    const where: Where<'transaction'> = [
+      {
+        state,
+        api_type,
+      },
+    ]
+    if (created_after) where.push(['created_at', '>=', new Date(created_after)])
+    if (updated_after) where.push(['updated_at', '>=', new Date(updated_after)])
 
     return this.db.get('transaction', where)
   }

--- a/src/lib/db/util.ts
+++ b/src/lib/db/util.ts
@@ -1,0 +1,29 @@
+import knex from 'knex'
+import { TABLE, Where } from './types.js'
+
+// reduces the where condition on a knex query. Gracefully handles undefined values in WhereMatch objects
+export const reduceWhere = <M extends TABLE>(
+  query: knex.Knex.QueryBuilder,
+  where?: Where<M>
+): knex.Knex.QueryBuilder => {
+  if (where) {
+    if (!Array.isArray(where)) {
+      where = [where]
+    }
+    query = where.reduce((acc, w) => {
+      if (Array.isArray(w)) {
+        return acc.where(w[0], w[1], w[2])
+      }
+      return acc.where(
+        Object.entries(w).reduce(
+          (acc, [k, v]) => {
+            if (v !== undefined) acc[k] = v
+            return acc
+          },
+          {} as Record<string, unknown>
+        )
+      )
+    }, query)
+  }
+  return query
+}

--- a/src/models/strings.ts
+++ b/src/models/strings.ts
@@ -17,6 +17,5 @@ export type HEX = `0x${string}`
  * ISO 8601 date string
  * @pattern (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))
  * @format date
- * @example "2023-05-04T09:47:32.393Z"
  */
 export type DATE = string

--- a/test/integration/offchain/attachment.test.ts
+++ b/test/integration/offchain/attachment.test.ts
@@ -43,8 +43,8 @@ describe('attachment', () => {
       expect(body).to.equal('attachment not found')
     })
 
-    it('returns 422 with invalid updated_since date', async () => {
-      const { status, body } = await get(app, `/v1/attachment?createdAt=foo`)
+    it('returns 422 with invalid created_after date', async () => {
+      const { status, body } = await get(app, `/v1/attachment?created_after=foo`)
       expect(status).to.equal(422)
       expect(body).to.contain({
         name: 'ValidateError',
@@ -75,7 +75,7 @@ describe('attachment', () => {
     })
 
     it('filters attachments based on created date', async () => {
-      const { status, body: attachments } = await get(app, `/v1/attachment?createdAt=2023-01-01T00:00:00.000Z`)
+      const { status, body: attachments } = await get(app, `/v1/attachment?created_after=2023-01-01T00:00:00.000Z`)
       expect(status).to.equal(200)
       expect(attachments).to.deep.equal([
         {
@@ -86,7 +86,7 @@ describe('attachment', () => {
     })
 
     it('returns empty array if none found based on created date', async () => {
-      const { status, body } = await get(app, `/v1/attachment?createdAt=3010-01-01T00:00:00.000Z`)
+      const { status, body } = await get(app, `/v1/attachment?created_after=3010-01-01T00:00:00.000Z`)
       expect(status).to.equal(200)
       expect(body).to.deep.equal([])
     })


### PR DESCRIPTION
Fixes an invalid handling of a filter parameter on the list transactions API. 

Few additional changes

1. made some improvements to how the db handles where clauses so that we can pass undefined values in to make writing these handlers easier.
2. made consistent our data filtering query params (`created_after`, `updated_after`). Later we can add `creadted_before` etc.
3. Removed date example on query parameter to prevent this being auto-filled into the swagger UI. This is really annoying that we can't change the default rendered but there's a ticket on the swagger UI repo for it https://github.com/swagger-api/swagger-ui/issues/5776
